### PR TITLE
Authentication

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,11 @@
 FROM python:2.7.12
 
+RUN apt-get update && apt-get install -y git
+WORKDIR /
+RUN git clone git@github.com:cloudbrain/cloudbrain.git
+WORKDIR /cloudbrain
+RUN python setup.py install --user
+
 ADD . /app
 WORKDIR /app
 RUN python setup.py install --user

--- a/cbws/auth.py
+++ b/cbws/auth.py
@@ -1,0 +1,34 @@
+import requests
+
+
+class CloudbrainAuth(object):
+
+    def __init__(self, base_url=None, token=None):
+        self.base_url = base_url or 'http://dockerhost:3000'
+        self.token = token or ''
+
+    def token_info(self, token=None):
+        token_url = self.base_url + '/oauth/token/info'
+        token = token or self.token
+
+        headers = {
+          'Authorization': 'Bearer %s' % token
+        }
+
+        response = requests.get(token_url, headers=headers, verify=False)
+        return response.json()
+
+    def vhost_info(self, token=None):
+        token_url = self.base_url + '/rabbitmq/vhost/info'
+        token = token or self.token
+
+        headers = {
+          'Authorization': 'Bearer %s' % token
+        }
+
+        response = requests.get(token_url, headers=headers, verify=False)
+        return response.json()
+
+    def get_vhost(self, token):
+        response = self.vhost_info(token)
+        return response['vhost']

--- a/cbws/auth.py
+++ b/cbws/auth.py
@@ -18,17 +18,32 @@ class CloudbrainAuth(object):
         response = requests.get(token_url, headers=headers, verify=False)
         return response.json()
 
-    def vhost_info(self, token=None):
-        token_url = self.base_url + '/rabbitmq/vhost/info'
+    def vhost_by_token(self, token=None):
+        info_url = self.base_url + '/rabbitmq/vhost/info'
         token = token or self.token
 
         headers = {
           'Authorization': 'Bearer %s' % token
         }
 
-        response = requests.get(token_url, headers=headers, verify=False)
+        response = requests.get(info_url, headers=headers, verify=False)
         return response.json()
 
-    def get_vhost(self, token):
-        response = self.vhost_info(token)
+    def vhost_by_username(self, username=None):
+        info_url = self.base_url + '/rabbitmq/vhost/info'
+
+        headers = {}
+        body = {
+            "username": username
+        }
+
+        response = requests.post(info_url, data=body, headers=headers, verify=False)
+        return response.json()
+
+    def get_vhost_by_token(self, token):
+        response = self.vhost_by_token(token=token)
+        return response['vhost']
+
+    def get_vhost_by_username(self, username):
+        response = self.vhost_by_username(username=username)
         return response['vhost']

--- a/cbws/conf/ws_server_config.docker.json
+++ b/cbws/conf/ws_server_config.docker.json
@@ -1,0 +1,6 @@
+{
+  "ws_server_port": 31415,
+  "rabbitmq_address": "dockerhost",
+  "rabbitmq_user": "",
+  "rabbitmq_pwd": ""
+}

--- a/cbws/server.py
+++ b/cbws/server.py
@@ -1,6 +1,8 @@
 import pika
 import json
 import logging
+import os
+
 
 from collections import defaultdict
 from sockjs.tornado.conn import SockJSConnection
@@ -189,12 +191,13 @@ class TornadoSubscriber(object):
 
 
     def connect(self):
-        auth = CloudbrainAuth()
+        auth_url = os.environ.get("AUTH_URL", None)
+        auth = CloudbrainAuth(base_url=auth_url)
         if self.token:
             credentials = pika.PlainCredentials(self.token, '')
             vhost = auth.get_vhost_by_token(self.token)
             connection_params = pika.ConnectionParameters(
-                host='dockerhost', virtual_host=vhost, credentials=credentials)
+                host=self.rabbitmq_address, virtual_host=vhost, credentials=credentials)
         else:
             credentials = pika.PlainCredentials(self.rabbitmq_user, self.rabbitmq_pwd)
             vhost = getattr(self, 'rabbitmq_vhost', auth.get_vhost_by_username(self.rabbitmq_user))

--- a/cbws/server.py
+++ b/cbws/server.py
@@ -10,6 +10,8 @@ from tornado.web import Application
 
 from uuid import uuid4
 
+from cbws.auth import CloudbrainAuth
+
 _LOGGER = logging.getLogger()
 _LOGGER.setLevel(logging.INFO)
 
@@ -96,6 +98,7 @@ def _rt_stream_connection_factory(rabbitmq_address, rabbitmq_user, rabbitmq_pwd)
             device_name = stream_configuration['deviceName']
             device_id = stream_configuration['deviceId']
             metric = stream_configuration['metric']
+            token = stream_configuration['token']
             downsampling_factor = stream_configuration.get('downsampling_factor', 16)
             subscriber_id = str(uuid4())
 
@@ -109,7 +112,9 @@ def _rt_stream_connection_factory(rabbitmq_address, rabbitmq_user, rabbitmq_pwd)
                         rabbitmq_user=rabbitmq_user,
                         rabbitmq_pwd=rabbitmq_pwd,
                         metric_name=metric,
-                        queue_name=subscriber_id),
+                        queue_name=subscriber_id,
+                        token=token,
+                        ),
                     "downsampling_factor": downsampling_factor,
                     "total_records": 0
                 }
@@ -165,7 +170,7 @@ class TornadoSubscriber(object):
 
 
     def __init__(self, callback, device_name, device_id, rabbitmq_address, rabbitmq_user,
-                 rabbitmq_pwd, metric_name, queue_name):
+                 rabbitmq_pwd, metric_name, queue_name, token=None):
         self.callback = callback
         self.device_name = device_name
         self.device_id = device_id
@@ -178,15 +183,24 @@ class TornadoSubscriber(object):
         self.rabbitmq_user = rabbitmq_user
         self.rabbitmq_pwd = rabbitmq_pwd
         self.queue_name = queue_name
+        self.token = token
 
         self.consumer_tag = None
 
 
     def connect(self):
-        credentials = pika.PlainCredentials('cloudbrain', 'cloudbrain')
+        if self.token:
+            credentials = pika.PlainCredentials(self.token, '')
+            auth = CloudbrainAuth()
+            vhost = auth.get_vhost(self.token)
+            connection_params = pika.ConnectionParameters(
+                host='dockerhost', virtual_host=vhost, credentials=credentials)
+        else:
+            credentials = pika.PlainCredentials(self.rabbitmq_user, self.rabbitmq_pwd)
+            connection_params = pika.ConnectionParameters(
+                host=self.rabbitmq_address, credentials=credentials)
         self.connection = pika.adapters.tornado_connection.TornadoConnection(
-            pika.ConnectionParameters(
-                host=self.rabbitmq_address, credentials=credentials),
+            connection_params,
             self.on_connected,
             stop_ioloop_on_close=False,
             custom_ioloop=IOLoop.instance())

--- a/cbws/server.py
+++ b/cbws/server.py
@@ -12,7 +12,7 @@ from tornado.web import Application
 
 from uuid import uuid4
 
-from cbws.auth import CloudbrainAuth
+from cloudbrain.core.auth import CloudbrainAuth
 
 _LOGGER = logging.getLogger()
 _LOGGER.setLevel(logging.INFO)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 sockjs-tornado==1.0.2
 tornado==4.3
 pika==0.10
+requests==2.11.1


### PR DESCRIPTION
Adds authentication handling to the WS Server.
- Accepts auth token from client
- Resolves vhost from OAuth Server
- Maintains functionality on local environments when no token is present

Next step (after deploy) is to remove device id across the system. User's routing keys would then only be `device_name:metric` but be bucketed under a private vhost.

Currently, the auth url is set by an environment variable in production environments, or defaults to http://dockerhost:3000 for local setup.
