### PR TITLE
Breaking change: removes device id requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def findRequirements():
 
 
 setup(name="cwbs",
-      version="0.0.1",
+      version="0.1.0",
       description="CloudBrain websocket server",
       author="Alessio Della Motta, Marion Le Borgne, William Wnekowicz",
       url="https://github.com/cloudbrain/cloudbrain-websocket-server",


### PR DESCRIPTION
With the new auth mechanism in place, we're removing the need to have a unique 'device id' which we've often considered a 'user id'.

Instead, device_name itself will represent the unique routing key and users will be differentiated by their vhost.
